### PR TITLE
refactor(sample): migrate the host app to AndroidX

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,6 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.sumup:merchant-api:1.4.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,6 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'com.sumup:merchant-api:1.4.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.sumup.apisampleapp">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
       android:allowBackup="true"

--- a/app/src/main/java/com/sumup/apisampleapp/MainActivity.java
+++ b/app/src/main/java/com/sumup/apisampleapp/MainActivity.java
@@ -1,18 +1,18 @@
 package com.sumup.apisampleapp;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
+import androidx.appcompat.app.AppCompatActivity;
 import com.sumup.merchant.api.SumUpAPI;
 import com.sumup.merchant.api.SumUpPayment;
 import java.math.BigDecimal;
 import java.util.UUID;
 
-public class MainActivity extends Activity {
+public class MainActivity extends AppCompatActivity {
 
   private static final String AFFILIATE_KEY = "REPLACE_WITH_YOUR_AFFILIATE_KEY";
   private static final String APP_ID = "com.sumup.apisampleapp";
@@ -94,28 +94,25 @@ public class MainActivity extends Activity {
 
   @Override
   protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    super.onActivityResult(requestCode, resultCode, data);
     resetViews();
 
-    switch (requestCode) {
-      case REQUEST_CODE_PAYMENT:
-        if (data != null) {
-          Bundle extra = data.getExtras();
+    if (requestCode == REQUEST_CODE_PAYMENT && data != null) {
+      Bundle extra = data.getExtras();
+      if (extra == null) {
+        return;
+      }
 
-          mResultCode.setText(
-              getString(R.string.result_code_format, extra.getInt(SumUpAPI.Response.RESULT_CODE)));
-          mResultMessage.setText(
-              getString(R.string.message_format, extra.getString(SumUpAPI.Response.MESSAGE)));
+      mResultCode.setText(
+          getString(R.string.result_code_format, extra.getInt(SumUpAPI.Response.RESULT_CODE)));
+      mResultMessage.setText(
+          getString(R.string.message_format, extra.getString(SumUpAPI.Response.MESSAGE)));
 
-          String txCode = extra.getString(SumUpAPI.Response.TX_CODE);
-          mTxCode.setText(
-              txCode == null ? "" : getString(R.string.transaction_code_format, txCode));
+      String txCode = extra.getString(SumUpAPI.Response.TX_CODE);
+      mTxCode.setText(txCode == null ? "" : getString(R.string.transaction_code_format, txCode));
 
-          boolean receiptSent = extra.getBoolean(SumUpAPI.Response.RECEIPT_SENT);
-          mReceiptSent.setText(getString(R.string.receipt_sent_format, receiptSent));
-        }
-        break;
-      default:
-        break;
+      boolean receiptSent = extra.getBoolean(SumUpAPI.Response.RECEIPT_SENT);
+      mReceiptSent.setText(getString(R.string.receipt_sent_format, receiptSent));
     }
   }
 

--- a/app/src/main/java/com/sumup/apisampleapp/URLResponseActivity.java
+++ b/app/src/main/java/com/sumup/apisampleapp/URLResponseActivity.java
@@ -3,7 +3,6 @@ package com.sumup.apisampleapp;
 import android.net.Uri;
 import android.os.Bundle;
 import android.widget.TextView;
-
 import androidx.appcompat.app.AppCompatActivity;
 
 public class URLResponseActivity extends AppCompatActivity {

--- a/app/src/main/java/com/sumup/apisampleapp/URLResponseActivity.java
+++ b/app/src/main/java/com/sumup/apisampleapp/URLResponseActivity.java
@@ -1,11 +1,12 @@
 package com.sumup.apisampleapp;
 
-import android.app.Activity;
 import android.net.Uri;
 import android.os.Bundle;
 import android.widget.TextView;
 
-public class URLResponseActivity extends Activity {
+import androidx.appcompat.app.AppCompatActivity;
+
+public class URLResponseActivity extends AppCompatActivity {
 
   @Override
   public void onCreate(Bundle savedInstanceState) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.enableJetifier=true
+android.useAndroidX=true


### PR DESCRIPTION
Replace the legacy support appcompat dependency with AndroidX appcompat and enable AndroidX plus Jetifier for the sample project.

Move the sample activities onto AppCompatActivity while preserving the existing SumUp checkout and callback contract for integrators.